### PR TITLE
Automatic update of Sentry.AspNetCore to 2.0.3

### DIFF
--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.1" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.1" />
     <PackageReference Include="AspNetCore.Firebase.Authentication" Version="2.0.1" />
-    <PackageReference Include="Sentry.AspNetCore" Version="2.0.2" />
+    <PackageReference Include="Sentry.AspNetCore" Version="2.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Sentry.AspNetCore` to `2.0.3` from `2.0.2`
`Sentry.AspNetCore 2.0.3` was published at `2020-02-12T02:25:18Z`, 10 days ago

1 project update:
Updated `Server/Server.csproj` to `Sentry.AspNetCore` `2.0.3` from `2.0.2`

[Sentry.AspNetCore 2.0.3 on NuGet.org](https://www.nuget.org/packages/Sentry.AspNetCore/2.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
