### PR TITLE
Automatic update of Microsoft.Extensions.Configuration to 3.1.2

### DIFF
--- a/Worker/Worker.csproj
+++ b/Worker/Worker.csproj
@@ -14,14 +14,14 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.0" />
     <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.1" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="ffmpeg\**\*.*" ExcludeFromSingleFile="true" CopyToPublishDirectory="Always"/>
-    <Content Include="Startup.bat" ExcludeFromSingleFile="true" CopyToPublishDirectory="Always"/>
-    <Content Update="appsettings.*" ExcludeFromSingleFile="true" CopyToPublishDirectory="Always"/>
+    <Content Include="ffmpeg\**\*.*" ExcludeFromSingleFile="true" CopyToPublishDirectory="Always" />
+    <Content Include="Startup.bat" ExcludeFromSingleFile="true" CopyToPublishDirectory="Always" />
+    <Content Update="appsettings.*" ExcludeFromSingleFile="true" CopyToPublishDirectory="Always" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.Configuration` to `3.1.2` from `3.1.0`
`Microsoft.Extensions.Configuration 3.1.2` was published at `2020-02-18T16:33:16Z`, 10 days ago

1 project update:
Updated `Worker/Worker.csproj` to `Microsoft.Extensions.Configuration` `3.1.2` from `3.1.0`

[Microsoft.Extensions.Configuration 3.1.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Configuration/3.1.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
