### PR TITLE
Automatic update of Sentry.AspNetCore to 2.1.0

### DIFF
--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.1" />
     <PackageReference Include="AspNetCore.Firebase.Authentication" Version="2.0.1" />
-    <PackageReference Include="Sentry.AspNetCore" Version="2.0.3" />
+    <PackageReference Include="Sentry.AspNetCore" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Sentry.AspNetCore` to `2.1.0` from `2.0.3`
`Sentry.AspNetCore 2.1.0` was published at `2020-02-24T19:36:49Z`, 11 days ago

1 project update:
Updated `Server/Server.csproj` to `Sentry.AspNetCore` `2.1.0` from `2.0.3`

[Sentry.AspNetCore 2.1.0 on NuGet.org](https://www.nuget.org/packages/Sentry.AspNetCore/2.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
