### PR TITLE
Automatic update of Microsoft.AspNetCore.SpaServices.Extensions to 3.1.2

### DIFF
--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.9" />
     <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.2" />
     <PackageReference Include="AspNetCore.Firebase.Authentication" Version="2.0.1" />
     <PackageReference Include="Sentry.AspNetCore" Version="2.0.3" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.SpaServices.Extensions` to `3.1.2` from `3.1.1`
`Microsoft.AspNetCore.SpaServices.Extensions 3.1.2` was published at `2020-02-18T16:32:42Z`, 17 days ago

1 project update:
Updated `Server/Server.csproj` to `Microsoft.AspNetCore.SpaServices.Extensions` `3.1.2` from `3.1.1`

[Microsoft.AspNetCore.SpaServices.Extensions 3.1.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.SpaServices.Extensions/3.1.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
