### PR TITLE
Automatic update of Sentry.AspNetCore to 2.1.1

### DIFF
--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.2" />
     <PackageReference Include="AspNetCore.Firebase.Authentication" Version="2.0.1" />
-    <PackageReference Include="Sentry.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Sentry.AspNetCore" Version="2.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />

--- a/Worker/Worker.csproj
+++ b/Worker/Worker.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.1" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.2" />
-    <PackageReference Include="Sentry.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Sentry.AspNetCore" Version="2.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Sentry.AspNetCore` to `2.1.1` from `2.1.0`
`Sentry.AspNetCore 2.1.1` was published at `2020-03-19T14:55:51Z`, 8 days ago

2 project updates:
Updated `Worker/Worker.csproj` to `Sentry.AspNetCore` `2.1.1` from `2.1.0`
Updated `Server/Server.csproj` to `Sentry.AspNetCore` `2.1.1` from `2.1.0`

[Sentry.AspNetCore 2.1.1 on NuGet.org](https://www.nuget.org/packages/Sentry.AspNetCore/2.1.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
