### PR TITLE
Automatic update of Microsoft.Extensions.Hosting to 3.1.3

### DIFF
--- a/Worker/Worker.csproj
+++ b/Worker/Worker.csproj
@@ -10,7 +10,7 @@
     <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.2" />
     <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.1" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.9" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.Hosting` to `3.1.3` from `3.1.2`
`Microsoft.Extensions.Hosting 3.1.3` was published at `2020-03-24T17:15:29Z`, 10 days ago

1 project update:
Updated `Worker/Worker.csproj` to `Microsoft.Extensions.Hosting` `3.1.3` from `3.1.2`

[Microsoft.Extensions.Hosting 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Hosting/3.1.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
