### PR TITLE
Automatic update of Hangfire.Core to 1.7.10

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.7.9" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.10" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Hangfire.Core` to `1.7.10` from `1.7.9`
`Hangfire.Core 1.7.10` was published at `2020-04-02T08:35:24Z`, 8 days ago

1 project update:
Updated `Core/Core.csproj` to `Hangfire.Core` `1.7.10` from `1.7.9`

[Hangfire.Core 1.7.10 on NuGet.org](https://www.nuget.org/packages/Hangfire.Core/1.7.10)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
