### PR TITLE
Automatic update of Microsoft.AspNetCore.SpaServices.Extensions to 3.1.3

### DIFF
--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.9" />
     <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.3" />
     <PackageReference Include="AspNetCore.Firebase.Authentication" Version="2.0.1" />
     <PackageReference Include="Sentry.AspNetCore" Version="2.1.1" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.SpaServices.Extensions` to `3.1.3` from `3.1.2`
`Microsoft.AspNetCore.SpaServices.Extensions 3.1.3` was published at `2020-03-24T17:13:37Z`, 24 days ago

1 project update:
Updated `Server/Server.csproj` to `Microsoft.AspNetCore.SpaServices.Extensions` `3.1.3` from `3.1.2`

[Microsoft.AspNetCore.SpaServices.Extensions 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.SpaServices.Extensions/3.1.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
