### PR TITLE
Automatic update of Hangfire.Core to 1.7.11

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.7.9" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.11" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Hangfire.Core` to `1.7.11` from `1.7.9`
`Hangfire.Core 1.7.11` was published at `2020-04-15T11:38:02Z`, 9 days ago

1 project update:
Updated `Core/Core.csproj` to `Hangfire.Core` `1.7.11` from `1.7.9`

[Hangfire.Core 1.7.11 on NuGet.org](https://www.nuget.org/packages/Hangfire.Core/1.7.11)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
