### PR TITLE
Automatic update of Hangfire.AspNetCore to 1.7.11

### DIFF
--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -5,7 +5,7 @@
     <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.9" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.11" />
     <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.3" />

--- a/Worker/Worker.csproj
+++ b/Worker/Worker.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.2" />
     <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.1" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.9" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.2" />
     <PackageReference Include="Sentry.AspNetCore" Version="2.1.1" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Hangfire.AspNetCore` to `1.7.11` from `1.7.9`
`Hangfire.AspNetCore 1.7.11` was published at `2020-04-15T11:38:00Z`, 9 days ago

2 project updates:
Updated `Server/Server.csproj` to `Hangfire.AspNetCore` `1.7.11` from `1.7.9`
Updated `Worker/Worker.csproj` to `Hangfire.AspNetCore` `1.7.11` from `1.7.9`

[Hangfire.AspNetCore 1.7.11 on NuGet.org](https://www.nuget.org/packages/Hangfire.AspNetCore/1.7.11)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
