### PR TITLE
Automatic update of Hangfire.Redis.StackExchange to 1.8.3

### DIFF
--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.11" />
-    <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.2" />
+    <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.3" />
     <PackageReference Include="AspNetCore.Firebase.Authentication" Version="2.0.1" />

--- a/Worker/Worker.csproj
+++ b/Worker/Worker.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.3" />
-    <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.2" />
+    <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.3" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.3" />
     <PackageReference Include="Sentry.AspNetCore" Version="2.1.1" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Hangfire.Redis.StackExchange` to `1.8.3` from `1.8.2`
`Hangfire.Redis.StackExchange 1.8.3` was published at `2020-05-06T12:01:18Z`, 9 days ago

2 project updates:
Updated `Worker/Worker.csproj` to `Hangfire.Redis.StackExchange` `1.8.3` from `1.8.2`
Updated `Server/Server.csproj` to `Hangfire.Redis.StackExchange` `1.8.3` from `1.8.2`

[Hangfire.Redis.StackExchange 1.8.3 on NuGet.org](https://www.nuget.org/packages/Hangfire.Redis.StackExchange/1.8.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
