### PR TITLE
Automatic update of Microsoft.Extensions.Hosting to 3.1.4

### DIFF
--- a/Worker/Worker.csproj
+++ b/Worker/Worker.csproj
@@ -10,7 +10,7 @@
     <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.3" />
     <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.2" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.11" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.Hosting` to `3.1.4` from `3.1.3`
`Microsoft.Extensions.Hosting 3.1.4` was published at `2020-05-12T14:59:47Z`, 10 days ago

1 project update:
Updated `Worker/Worker.csproj` to `Microsoft.Extensions.Hosting` `3.1.4` from `3.1.3`

[Microsoft.Extensions.Hosting 3.1.4 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Hosting/3.1.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
